### PR TITLE
DM-34639: rename <name>ID fields to "salindex": RFC-849

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .cache
 .pytest_cache
-.coverage*
+.coverage
+.hypothesis
 pytest_session.txt
 .scon*
 *.log

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -9,9 +9,16 @@ Version History
 v1.10.0
 -------
 
+* Update for ts_sal 6.2, which is required:
+
+  * Remove all references to the "priority" field (RFC-848).
+  * Rename "{component_name}ID" fields to "salIndex" (RFC-849).
+
 * Add support for standard Avro schema evolution by specifying a default value for each field.
   This adds automatic schema evolution support for adding and removing fields, but does not support changing the type of an existing field.
   Use a default value of 0 for float fields and float array items, because that matches the default for Kafka and DDS.
+* ``setup.cfg``: specify asyncio_mode=auto.
+* git ignore ``.hypothesis``.
 
 v1.9.0
 ------

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ exclude =
 [tool:pytest]
 addopts = --flake8  --black --ignore-glob=*version.py
 flake8-ignore = E133 E203 E226 E228 N802 N803 N806 N812 N813 N815 N816 W503
+asyncio_mode = auto
 
 [metadata]
 version = attr: setuptools_scm.get_version

--- a/tests/test_kafka_producer_factory.py
+++ b/tests/test_kafka_producer_factory.py
@@ -88,14 +88,14 @@ class KafkaProducerFactoryTestCase(unittest.IsolatedAsyncioTestCase):
             avro_schema = {
                 "name": topic_name,
                 "type": "record",
-                "fields": [{"name": "TestID", "type": "long"}],
+                "fields": [{"name": "salIndex", "type": "long"}],
             }
             producer = await kafka_factory.make_producer(avro_schema=avro_schema)
             assert producer.bootstrap_servers == config.broker_url
             assert producer.sent_data == []
             expected_name_value_list = []
             for i in range(10):
-                value = {"TestID": i}
+                value = {"salIndex": i}
                 expected_name_value_list.append((topic_name, value))
                 await producer.send_and_wait(topic_name, value=value)
             sent_name_value_list = [item[0:2] for item in producer.sent_data]

--- a/tests/test_make_avro_schema.py
+++ b/tests/test_make_avro_schema.py
@@ -64,7 +64,7 @@ class MakeAvroSchemaTestCase(unittest.IsolatedAsyncioTestCase):
                 "private_efdStamp": "double",
                 "private_kafkaStamp": "double",
                 # standard fields not in the XML
-                "TestID": "long",
+                "salIndex": "long",
                 "private_revCode": "string",
                 "private_sndStamp": "double",
                 "private_rcvStamp": "double",
@@ -137,7 +137,7 @@ class MakeAvroSchemaTestCase(unittest.IsolatedAsyncioTestCase):
                             schema_item["description"]
                             == "TAI time at which the Kafka message was created."
                         )
-                    elif field_name == "TestID":
+                    elif field_name == "salIndex":
                         # SAL 4.0 provides no metadata for this topic
                         # but SAL 4.1 may.
                         pass

--- a/tests/test_make_avro_schema.py
+++ b/tests/test_make_avro_schema.py
@@ -72,8 +72,6 @@ class MakeAvroSchemaTestCase(unittest.IsolatedAsyncioTestCase):
                 "private_origin": "long",
                 "private_identity": "string",
                 "private_revCode": "string",
-                # This standard field is only present for events.
-                "priority": "long",
                 # fields in the XML
                 "boolean0": "boolean",
                 "byte0": "long",
@@ -89,8 +87,6 @@ class MakeAvroSchemaTestCase(unittest.IsolatedAsyncioTestCase):
                 "float0": "double",
                 "double0": "double",
                 "string0": "string",
-                # another standard field not in the XML
-                "priority": "long",
             }
             if hasattr(topic_sample, "private_host"):
                 # Deprecated, should be gone in ts_sal 6


### PR DESCRIPTION
Warning: Jenkins CI jobs will fail until ts_sal is updated