### PR TITLE
[DM-34800] Add SASL configuration to ts_salkafka 

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,13 @@
 Version History
 ###############
 
+v1.11.0
+-------
+
+* Add support for SASL authentication using SASL_PLAINTEXT protocol and SCRAM-SHA-512 method.
+  This adds the ``--username`` and ``--password`` CLI options that can be used to
+  connect the secured Kafka broker.
+
 v1.10.1
 -------
 

--- a/python/lsst/ts/salkafka/component_producer_set.py
+++ b/python/lsst/ts/salkafka/component_producer_set.py
@@ -211,6 +211,8 @@ class ComponentProducerSet:
             args.wait_for_ack = int(args.wait_for_ack)
         kafka_config = KafkaConfiguration(
             broker_url=args.broker_url,
+            sasl_plain_username=args.username,
+            sasl_plain_password=args.password,
             registry_url=args.registry_url,
             partitions=args.partitions,
             replication_factor=args.replication_factor,
@@ -314,6 +316,18 @@ class ComponentProducerSet:
             help="Kafka broker URL, without the transport. "
             "Example 'my.kafka:9000'. "
             "Required unless --validate or --show-schema are specified.",
+        )
+        parser.add_argument(
+            "--username",
+            default=None,
+            dest="username",
+            help="Kafka username for SASL authentication.",
+        )
+        parser.add_argument(
+            "--password",
+            default=None,
+            dest="password",
+            help="Kafka password for SASL authentication.",
         )
         parser.add_argument(
             "--registry",

--- a/python/lsst/ts/salkafka/component_producer_set.py
+++ b/python/lsst/ts/salkafka/component_producer_set.py
@@ -209,6 +209,10 @@ class ComponentProducerSet:
             parser.error(f"--partitions={args.partitions} must be positive")
         if args.wait_for_ack != "all":
             args.wait_for_ack = int(args.wait_for_ack)
+        if args.username and args.password is None:
+            parser.error("You must specify --password if you specify --username.")
+        if args.password and args.username is None:
+            parser.error("You must specify --username if you specify --password.")
         kafka_config = KafkaConfiguration(
             broker_url=args.broker_url,
             sasl_plain_username=args.username,
@@ -321,13 +325,15 @@ class ComponentProducerSet:
             "--username",
             default=None,
             dest="username",
-            help="Kafka username for SASL authentication.",
+            help="Kafka username for SASL authentication. "
+            "Required if --password is specified.",
         )
         parser.add_argument(
             "--password",
             default=None,
             dest="password",
-            help="Kafka password for SASL authentication.",
+            help="Kafka password for SASL authentication. "
+            "Required if --username is specified.",
         )
         parser.add_argument(
             "--registry",

--- a/python/lsst/ts/salkafka/kafka_producer_factory.py
+++ b/python/lsst/ts/salkafka/kafka_producer_factory.py
@@ -59,11 +59,13 @@ class KafkaConfiguration:
         * 0: do not wait (unsafe)
         * 1: wait for first kafka broker to respond (recommended)
         * "all": wait for all kafka brokers to respond
-    sasl_plain_username : `str`
+    sasl_plain_username : `None` | `str`
         username for SASL authentication.
+        If specified then you must also specify sasl_plain_password.
         Default: None
     sasl_plain_password : `str`
         password for SASL authentication.
+        If specified then you must also specify sasl_plain_username.
         Default: None
     """
 
@@ -72,13 +74,18 @@ class KafkaConfiguration:
     partitions: int
     replication_factor: int
     wait_for_ack: typing.Union[int, str]
-    sasl_plain_username: str = None
-    sasl_plain_password: str = None
+    sasl_plain_username: None | str = None
+    sasl_plain_password: None | str = None
 
     def __post_init__(self):
         if self.wait_for_ack not in (0, 1, "all"):
             raise ValueError(
                 f"wait_for_ack={self.wait_for_ack!r} must be one of 0, 1, 'all'"
+            )
+        if (self.sasl_plain_username is None) != (self.sasl_plain_password is None):
+            raise ValueError(
+                "Both or neither of 'config.sasl_plain_username' "
+                "and 'config.sasl_plain_password' must be specified."
             )
 
 

--- a/python/lsst/ts/salkafka/kafka_producer_factory.py
+++ b/python/lsst/ts/salkafka/kafka_producer_factory.py
@@ -110,10 +110,19 @@ class KafkaProducerFactory:
                     "sasl.password": self.config.sasl_plain_password,
                 }
             )
-        else:
+        elif (
+            self.config.sasl_plain_username is None
+            and self.config.sasl_plain_password is None
+        ):
             self.broker_client = AdminClient(
                 {"bootstrap.servers": self.config.broker_url}
             )
+        else:
+            raise ValueError(
+                "Both or neither of 'self.config.sasl_plain_username' "
+                "and 'self.config.sasl_plain_password' must be set."
+            )
+
         self.start_task = asyncio.ensure_future(self.start())
 
     async def start(self):
@@ -195,13 +204,22 @@ class KafkaProducerFactory:
                 sasl_plain_username=self.config.sasl_plain_username,
                 sasl_plain_password=self.config.sasl_plain_password,
             )
-        else:
+        elif (
+            self.config.sasl_plain_username is None
+            and self.config.sasl_plain_password is None
+        ):
             producer = AIOKafkaProducer(
                 loop=asyncio.get_running_loop(),
                 bootstrap_servers=self.config.broker_url,
                 acks=self.config.wait_for_ack,
                 value_serializer=serializer,
             )
+        else:
+            raise ValueError(
+                "Both or neither of 'self.config.sasl_plain_username' "
+                "and 'self.config.sasl_plain_password' must be set."
+            )
+
         await producer.start()
         return producer
 


### PR DESCRIPTION
In Sasquatch access to Kafka brokers is now authenticated via SASL (Simple Authentication and Security Layer). This PR adds SASL authentication to the `ts_salkafka` client using the SASL_PLAINTEXT protocol and SCRAM-SHA-512 method. 

`ts_salkafa` is going to use the `ts-salkafka` Kafka user, and the password will be provided via a k8s secret. This requires a change on the `ts_salkafka` Helm chart which will be implemented in another PR.




